### PR TITLE
Bump esbuild to version 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ]
   },
   "dependencies": {
-    "esbuild": "^0.11.15",
+    "esbuild": "^0.12.0",
     "picomatch": "^2.2.2",
     "sass": "^1.32.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,10 +599,10 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-esbuild@^0.11.15:
-  version "0.11.15"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.15.tgz#d92250e1755294f84bc7a83ed191e60baadf7b6a"
-  integrity sha512-Hh40byWZZgYbiLhcoOWiOUIy8yUYQeCEA4F9feWytToD2jGfJ1X4VPf5dsqj6vRL29H3YmFqZsxIJa5q0ifB3g==
+esbuild@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.0.tgz#84f49105994f437c2fe307daa5b32e8885c3d10d"
+  integrity sha512-vUKQ6TiMWGCtI7jLSrMmBVY4aj4As9J6NsFnrS9insd2F5KKD3mr1jUe+SB4KsMACkQIGtTtkksPpRmmqgxDHw==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
A new version of esbuild was released, [with some important changes for CSS](https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#0120).