### PR TITLE
Add mapper option to custom path resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The **options** passed to the plugin are a superset of the sass [Options](https:
 |implementation|string|`"sass"`|
 |transform|function|undefined|
 |exclude|regex|undefined|
+|importMapper|function|undefined|
 
 
 If you want to have different loaders for different parts of your code you can pass `type` an array. 
@@ -119,6 +120,34 @@ await esbuild.build({
     ...
     plugins: [sassPlugin({
         exclude: /^http:\/\//,  // ignores urls
+    })]
+})
+```
+
+### ImportMapper Option
+Function to customize re-map import path, both `import` in ts code and `@import` 
+in scss coverd.   
+You can use this option to re-map import paths like tsconfig's `paths` option.   
+
+e.g.
+```json
+//tsconfig
+{
+  "compilerOptions": {
+    "baseUrl": ".", 
+    "paths": {
+      "@img/*": ["./assets/images/*"] //map image files
+    }
+  }
+}
+```
+Now you can resolve these paths with `importMapper`
+```javascript
+await esbuild.build({
+    ...
+    plugins: [sassPlugin({
+        importMapper: (path)=>
+          path.replace(/^@img\//,"./assets/images/")
     })]
 })
 ```

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,7 +1,7 @@
 import {SassPluginOptions} from "./index";
 import resolve from "resolve";
 
-export function createSassImporter({basedir = process.cwd(), mapper }: SassPluginOptions) {
+export function createSassImporter({basedir = process.cwd(), importMapper }: SassPluginOptions) {
 
     const opts = {basedir, extensions: [".scss", ".sass", ".css"]};
 
@@ -9,8 +9,8 @@ export function createSassImporter({basedir = process.cwd(), mapper }: SassPlugi
         if (url.startsWith("~")) {
             url = url.slice(1);
         }
-        if (mapper) {
-            url = mapper(url)
+        if (importMapper) {
+            url = importMapper(url)
         }
         try {
             return {file: resolve.sync(url, opts)};

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,13 +1,16 @@
 import {SassPluginOptions} from "./index";
 import resolve from "resolve";
 
-export function createSassImporter({basedir = process.cwd()}: SassPluginOptions) {
+export function createSassImporter({basedir = process.cwd(), mapper }: SassPluginOptions) {
 
     const opts = {basedir, extensions: [".scss", ".sass", ".css"]};
 
     return function importer(url, prev) {
         if (url.startsWith("~")) {
             url = url.slice(1);
+        }
+        if (mapper) {
+            url = mapper(url)
         }
         try {
             return {file: resolve.sync(url, opts)};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@ import {Importer, types} from "sass";
 export type Type = "css" | "style" | "css-text" | "lit-css"
 
 export type SassPluginOptions = {
+    /**
+     * Mapper function to custom resolve path
+     */
+    mapper?:(url: string) => string
 
     /**
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,10 @@ export type Type = "css" | "style" | "css-text" | "lit-css"
 
 export type SassPluginOptions = {
     /**
-     * Mapper function to custom resolve path
+     * Function to transform import path. Not just paths by @import 
+     * directive, but also paths imported by ts code.
      */
-    mapper?:(url: string) => string
+    importMapper?:(url: string) => string
 
     /**
      *

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -65,7 +65,7 @@ export function sassPlugin(options: SassPluginOptions = {}): Plugin {
             resolveDir = dirname(importer);
         }
 
-        const mapper = options.mapper
+        const mapper = options.importMapper
         if(mapper) {
             path = mapper(path)
         }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -64,6 +64,12 @@ export function sassPlugin(options: SassPluginOptions = {}): Plugin {
         if (!resolveDir) {
             resolveDir = dirname(importer);
         }
+
+        const mapper = options.mapper
+        if(mapper) {
+            path = mapper(path)
+        }
+
         const paths = options.includePaths ? [resolveDir, ...options.includePaths] : [resolveDir];
         return require.resolve(path, {paths});
     }


### PR DESCRIPTION
I'm trying to bundle [momentum-ui web component](https://github.com/momentum-design/momentum-ui/tree/master/web-components) with esbuild and this plugin. But the scss code use custom path defined in `tsconfig`:
```json
  "paths": {
      "@/*": ["./*"],
      "@css/*": ["./assets/styles/*"],
      "@img/*": ["./assets/images/*"]
    }
```
So I add this `mapper` thing.  My use case is like: 
```javascript
  sassPlugin({
      type: "lit-css",
      quietDeps: true,
      includePaths: [process.cwd()],
      mapper: url => {
        let path = url;
        if (/^@\//.test(path)) {
          path = resolve(process.cwd(), path.replace(/^@\//, "./src/"));
        }
        return path;
      }
    })
```

Hope it's useful to others. 
I can add some documentation if you this feature is a good idea.