### PR TITLE
Expose sourcemaps to transform

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,7 +1,10 @@
 import {SassPluginOptions} from "./index";
 import resolve from "resolve";
+import type { LegacyImporter } from "sass";
 
-export function createSassImporter({basedir = process.cwd(), importMapper }: SassPluginOptions) {
+export function createSassImporter(
+    {basedir = process.cwd(), importMapper }: SassPluginOptions
+): LegacyImporter<'sync'|'async'> {
 
     const opts = {basedir, extensions: [".scss", ".sass", ".css"]};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,12 @@ export type SassPluginOptions = {
      *
      * @default undefined
      */
-    transform?: (css: string, resolveDir: string, filePath: string) => string | OnLoadResult | Promise<string | OnLoadResult>;
+    transform?: (
+        css: string, 
+        resolveDir: string, 
+        filePath: string,
+        map?: Buffer
+    ) => string | OnLoadResult | Promise<string | OnLoadResult>;
 
     /**
      *


### PR DESCRIPTION
I originally raised a request for relative url rewriting in issue #19, and it looks like [several](https://github.com/netbox-community/netbox/issues/7068) [other](https://github.com/glromeo/esbuild-sass-plugin/issues/35) [people](https://github.com/glromeo/esbuild-sass-plugin/issues/48) have had similar requests since then. The issue was originally closed due to being outside the scope of this project.

That is perfectly understandable, however, as it turns out there is very little that needs to be done in order to allow someone else to implement a `result-url-loader-plugin`-esque solution on their own. Specifically, the only thing that needs to exist is that the sourcemap generated by sass needs to be exposed to the `transform` method of this plugin.

So that's what this PR does: it simply exposes the source maps if any are generated (setting the `sourceMap` property to `sourceMap: 'out.map'` will generate them, for example) as an optional parameter of the transform method. It's fully backward compatible with any current uses of this plugin. 

And if anyone comes asking for relative url writing, you can tell them all of the pieces necessary to do so are now available (which I'm planning on doing. If it works, I'll release a plugin for your plugin).