### PR TITLE
Added `isRoot` param to `precompile` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ const path = require('path')
 await esbuild.build({
   ...,
   plugins: [sassPlugin({
-    precompile(source, pathname, isRoot) {
+    precompile(source, pathname) {
       const basedir = path.dirname(pathname)
       return source.replace(/(url\(['"]?)(\.\.?\/)([^'")]+['"]?\))/g, `$1${basedir}/$2$3`)
     }
@@ -227,7 +227,7 @@ const context = { color: "blue" }
 await esbuild.build({
   ...,
   plugins: [sassPlugin({
-    precompile(source, pathname, isRoot) {
+    precompile(source, pathname) {
       const prefix = /\/included\.scss$/.test(pathname) ? `
             $color: ${context.color};
           ` : env

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ await esbuild.build({
 ```
 
 #### - Globals and other Shims (like sass-loader's additionalData)
-Look for a complete example in the [precompile](https://github.com/glromeo/esbuild-sass-plugin/tree/main/test/fixture/precompile) fixture
+Look for a complete example in the [precompile](https://github.com/glromeo/esbuild-sass-plugin/tree/main/test/fixture/precompile) fixture.
 
 Prepending a variable for a specific `pathname`:
 ```javascript
@@ -237,7 +237,7 @@ await esbuild.build({
 })
 ```
 
-Prepending an `@import` of globals file only for the main file that triggered the compilation (to avoid importing it twice).
+Prepending an `@import` of globals file only for the main file that triggered the compilation (to avoid importing it twice):
 ```javascript
 const context = { color: "blue" }
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ const path = require('path')
 await esbuild.build({
   ...,
   plugins: [sassPlugin({
-    precompile(source, pathname) {
+    precompile(source, pathname, isRoot) {
       const basedir = path.dirname(pathname)
       return source.replace(/(url\(['"]?)(\.\.?\/)([^'")]+['"]?\))/g, `$1${basedir}/$2$3`)
     }
@@ -237,7 +237,7 @@ await esbuild.build({
 })
 ```
 
-Prepending an `@import` of globals file only for the main file that triggered the compilation (to avoid importing it twice):
+Prepending an `@import` of globals file only for the root file that triggered the compilation (to avoid nested files from importing it again):
 ```javascript
 const context = { color: "blue" }
 

--- a/README.md
+++ b/README.md
@@ -220,17 +220,32 @@ await esbuild.build({
 #### - Globals and other Shims (like sass-loader's additionalData)
 Look for a complete example in the [precompile](https://github.com/glromeo/esbuild-sass-plugin/tree/main/test/fixture/precompile) fixture
 
+Prepending a variable for a specific `pathname`:
 ```javascript
 const context = { color: "blue" }
 
 await esbuild.build({
   ...,
   plugins: [sassPlugin({
-    precompile(source, pathname) {
+    precompile(source, pathname, isRoot) {
       const prefix = /\/included\.scss$/.test(pathname) ? `
             $color: ${context.color};
           ` : env
       return prefix + source
+    }
+  })]
+})
+```
+
+Prepending an `@import` of globals file only for the main file that triggered the compilation (to avoid importing it twice).
+```javascript
+const context = { color: "blue" }
+
+await esbuild.build({
+  ...,
+  plugins: [sassPlugin({
+    precompile(source, pathname, isRoot) {
+      return isRoot ? `@import '/path/to/globals.scss';\n${source}` : source
     }
   })]
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export type SassPluginOptions = StringOptions<'sync'> & {
   /**
    *
    */
-  precompile?: (source: string, path: string) => string
+  precompile?: (source: string, path: string, isRoot?: boolean) => string
 
   /**
    * Should rewrite leftover css imports starting with ~ so that esbuild can resolve them?

--- a/src/render.ts
+++ b/src/render.ts
@@ -68,7 +68,7 @@ export function createRenderer(options: SassPluginOptions = {}, sourcemap: boole
 
     let source = fs.readFileSync(path, 'utf-8')
     if (options.precompile) {
-      source = options.precompile(source, path)
+      source = options.precompile(source, path, true)
     }
 
     const syntax = fileSyntax(path)
@@ -90,7 +90,7 @@ export function createRenderer(options: SassPluginOptions = {}, sourcemap: boole
           const pathname = fileURLToPath(canonicalUrl)
           let contents = fs.readFileSync(pathname, 'utf8')
           if (options.precompile) {
-            contents = options.precompile(contents, pathname)
+            contents = options.precompile(contents, pathname, false)
           }
           return {
             contents,


### PR DESCRIPTION
I wasn't enable to differentiate if the file I wanted to manipulate its source was the one that triggered the compilation or it was a nested `@import` file within it. 

I needed to only prepend some global files only to the root file.

A third parameter was added to precomiple:

```typescript
precompile(source: string, pathname: string, isRoot: boolean): string
```