### PR TITLE
Allow using postcssModules without styles being automatically injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ esbuild.build({
 })
 
 ```
+You may pass `inject: false` in `postcssModules` options to not automatically create a style element - similar to `css-text` behavior.
+
 `postcssModules` produces Javascript modules which are handled by esbuild's `js` loader, so the `type` option is **ignored**
 
 `postcssModules` also accepts an optional array of plugins for PostCSS as second parameter.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,12 @@ function requireTool(module: string, basedir?: string) {
   }
 }
 
+// postcssModules with inject: false
+const postcssModulesModule = (cssText: string, cssModulesClasses: string) => `\
+export const css = \`${cssText.replace(/([$`\\])/g, '\\$1')}\`;
+export const classes = ${cssModulesClasses};
+`;
+
 const cssTextModule = cssText => `\
 export default \`
 ${cssText.replace(/([$`\\])/g, '\\$1')}\`;
@@ -134,6 +140,7 @@ export function parseNonce(nonce: string | undefined): string | undefined {
 
 export type PostcssModulesParams = Parameters<PostcssModulesPlugin>[0] & {
   basedir?: string
+  inject?: boolean
 };
 
 export function postcssModules(options: PostcssModulesParams, plugins: AcceptedPlugin[] = []) {
@@ -156,7 +163,9 @@ export function postcssModules(options: PostcssModulesParams, plugins: AcceptedP
     ]).process(source, {from: path, map: false})
 
     return {
-      contents: `${makeModule(css, 'style', this.nonce)}export default ${cssModule};`,
+      contents: options.inject === false
+          ? postcssModulesModule(css, cssModule)
+          : `${makeModule(css, 'style', this.nonce)}export default ${cssModule};`,
       loader: 'js'
     }
   }


### PR DESCRIPTION
When using postcssModules, the value of `type` is ignored. While for many use cases this may be fine, in others it may be an important drawback.

This PR allows passing `inject: false` to postcssModules' options to replace the default behaviour (like `type: style`) with a side-effect free behaviour
(like `type: css-text`).

Importing a sass file with this set would look like `import { classes, css } from "..."`.