### PR TITLE
fix: use absWorkingDir as root if provided. fixes #114

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,10 +20,6 @@ export function sassPlugin(options: SassPluginOptions = {}): Plugin {
   if (options.includePaths) {
     console.log(`'includePaths' option is deprecated, please use 'loadPaths' instead`)
   }
-  options.loadPaths = Array.from(new Set([
-    ...options.loadPaths || modulesPaths(),
-    ...options.includePaths || []
-  ]))
 
   const type = options.type ?? 'css'
 
@@ -36,6 +32,11 @@ export function sassPlugin(options: SassPluginOptions = {}): Plugin {
   return {
     name: 'sass-plugin',
     setup({initialOptions, onResolve, onLoad, resolve}) {
+
+      options.loadPaths = Array.from(new Set([
+        ...options.loadPaths || modulesPaths(initialOptions.absWorkingDir),
+        ...options.includePaths || []
+      ]))
 
       const {
         sourcemap,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,8 +9,8 @@ import {SyncOpts} from 'resolve'
 
 export const RELATIVE_PATH = /^\.\.?\//
 
-export function modulesPaths(): string[] {
-  let path = process.cwd()
+export function modulesPaths(absWorkingDir?: string): string[] {
+  let path = absWorkingDir || process.cwd()
   let {root} = parse(path)
   let found: string[] = []
   while (path !== root) {


### PR DESCRIPTION
This PR fixes #114 by using `initialOptions.absWorkingDir` as the root directory for module resolution, if provided to the esbuild config. See https://github.com/glromeo/esbuild-sass-plugin/issues/114#issuecomment-1367395679 for details on and cause of the bug. 