### PR TITLE
fix: use correct sourcemap line numbers with css-text and lit-css

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,14 +91,12 @@ function requireTool(module: string, basedir?: string) {
 }
 
 const cssTextModule = cssText => `\
-export default \`
-${cssText.replace(/([$`\\])/g, '\\$1')}\`;
+export default \`${cssText.replace(/([$`\\])/g, '\\$1')}\`;
 `
 
 const cssResultModule = cssText => `\
 import {css} from "lit-element/lit-element.js";
-export default css\`
-${cssText.replace(/([$`\\])/g, '\\$1')}\`;
+export default css\`${cssText.replace(/([$`\\])/g, '\\$1')}\`;
 `
 
 const styleModule = (cssText: string, nonce?: string) => nonce ? `\

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -181,7 +181,7 @@ describe('e2e tests', function () {
       };
     `)
 
-    expect(bundle).to.have.string('var hello_world_default = i`\n' +
+    expect(bundle).to.have.string('var hello_world_default = i`' +
       '.banner {\n' +
       '  font-family: sans-serif;\n' +
       '  color: blue;\n' +


### PR DESCRIPTION
Hi there! Thanks for this awesome plugin 😄 

We noticed an issue where our sourcemaps were broken when using `type: 'css-text'` and the sources would be pointed to the previous line. When adding the same sass to our global stylesheets everything worked as expected, upon reading the source I noticed the plugin would add a leading newline to modules that use `css-text`. When removing that leading new line our sourcemaps now work as expected, which makes sense as the transformed output currently has a leading newline which isn't represented in the sourcemap.

While I was there, I also applied the same fix to `lit-css`.

