### PR TITLE
fix: support multiple plugin instances using the transform option

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,8 @@ const cwd = process.cwd()
 export const DEFAULT_FILTER = /\.(s[ac]ss|css)$/
 
 export const posixRelative = require('path').sep === '/'
-  ? (path: string) => `css-chunk:${relative(cwd, path)}`
-  : (path: string) => `css-chunk:${relative(cwd, path).replace(/\\/g, '/')}`
+  ? (path: string) => relative(cwd, path)
+  : (path: string) => relative(cwd, path).replace(/\\/g, '/')
 
 export function modulesPaths(absWorkingDir?: string): string[] {
   let path = absWorkingDir || process.cwd()

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -321,7 +321,14 @@ describe('e2e tests', function () {
       format: 'esm',
       plugins: [
         sassPlugin({
-          filter: /\.module\.scss$/,
+          filter: /common\.module\.scss$/,
+          transform: postcssModules({
+            localsConvention: 'camelCaseOnly'
+          }),
+          type: 'css'
+        }),
+        sassPlugin({
+          filter: /example\.module\.scss$/,
           transform: postcssModules({
             localsConvention: 'camelCaseOnly'
           }),

--- a/test/fixture/multiple/build.mjs
+++ b/test/fixture/multiple/build.mjs
@@ -21,7 +21,14 @@ esbuild.build({
   format: 'esm',
   plugins: [
     sassPlugin({
-      filter: /\.module\.scss$/,
+      filter: /common\.module\.scss$/,
+      transform: postcssModules({
+        localsConvention: 'camelCaseOnly'
+      }),
+      type: 'css'
+    }),
+    sassPlugin({
+      filter: /example\.module\.scss$/,
       transform: postcssModules({
         localsConvention: 'camelCaseOnly'
       }),


### PR DESCRIPTION
When using multiple instances of the plugin and the `transform` option, the plugin fails with an error like so:
```
ERROR: Do not know how to load path: esbuild-sass-plugin:css-chunk:test/fixture/multiple/src/modules/example.module.scss
```

This is due to the namespace and css chunk prefix being shared between all plugin instances. We fix the bug by adding a simple unique incrementing id to the namespace and css prefix used by the plugin.